### PR TITLE
Add proxymode code to project

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -7,18 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
-# G-Maintainer: alice <xlai@suse.com>
-
 use strict;
 use warnings;
 use File::Basename;
-use base "virt_autotest_base";
 use testapi;
-use virt_utils;
+use base "opensusebasetest";
 
 sub install_package() {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
+
     if ($qa_server_repo) {
         script_run "zypper --non-interactive rr server-repo";
         assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
@@ -26,51 +23,24 @@ sub install_package() {
     else {
         die "There is no qa server repo defined variable QA_HEAD_REPO\n";
     }
+    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
 
-    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 90);
-    assert_script_run("zypper --non-interactive -n in qa_lib_virtauto",      1800);
+    assert_script_run("zypper --non-interactive -n in qa_lib_virtauto", 1800);
+
+    if (get_var("PROXY_VIRT_AUTOTEST")) {
+        if (get_var("XEN")) {
+            assert_script_run("zypper --non-interactive -n in -t pattern xen_server", 1800);
+        }
+    }
 }
-
-sub update_package() {
-    my $self           = shift;
-    my $test_type      = get_var('TEST_TYPE', 'Milestone');
-    my $update_pkg_cmd = "source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms";
-    if ($test_type eq 'Milestone') {
-        $update_pkg_cmd = $update_pkg_cmd . " off on off";
-    }
-    else {
-        $update_pkg_cmd = $update_pkg_cmd . " off off on";
-    }
-
-    $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
-
-    my $ret = $self->execute_script_run($update_pkg_cmd, 7200);
-    save_screenshot;
-
-    upload_logs("/tmp/update_virt_rpms.log");
-
-    if ($ret !~ /Need to reboot system to make the rpms work/m) {
-        die " Update virt rpms fail, going to terminate following test!";
-    }
-
-}
-
 
 sub run() {
-    my $self = shift;
-
     install_package;
-
-    $self->update_package();
-
-    setup_console_in_grub;
-
-    repl_repo_in_sourcefile();
 }
 
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/proxymode_conn_slave.pm
+++ b/tests/virt_autotest/proxymode_conn_slave.pm
@@ -7,23 +7,25 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
-# G-Maintainer: alice <xlai@suse.com>
-
 use strict;
 use warnings;
 use File::Basename;
+use base "opensusebasetest";
 use testapi;
-use base "reboot_and_wait_up";
+
+use base "proxymodeapi";
 
 sub run() {
-    my $self    = shift;
-    my $timeout = 300;
-    $self->reboot_and_wait_up($timeout);
+    my $self         = shift;
+    my $ipmi_machine = get_var("IPMI_HOSTNAME");
+
+    $self->restart_host();
+    $self->connect_slave();
+    $self->check_prompt_for_boot();
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {important => 1};
 }
 
 1;

--- a/tests/virt_autotest/proxymode_init_pxe_install.pm
+++ b/tests/virt_autotest/proxymode_init_pxe_install.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+use virt_autotest_base;
+
+use base "proxymodeapi";
+
+sub run() {
+    my $self = shift;
+
+    $self->restart_host();
+    ## Login to command line of pxe management
+    $self->connect_slave();
+    assert_screen "proxy_virttest-pxe", 300;
+    send_key_until_needlematch "proxy_virttest-pxe-edit-prompt", "esc", 10, 5;
+    sleep 5;
+
+    # Execute installation command on pxe management cmd console
+    my $type_speed = 20;
+    my $image_path = get_var("HOST_IMG_URL");
+
+    type_string ${image_path} . " ", $type_speed;
+    type_string "vga=791 ",                                                              $type_speed;
+    type_string "Y2DEBUG=1 ",                                                            $type_speed;
+    type_string "video=1024x768-16 ",                                                    $type_speed;
+    type_string "console=ttyS1,115200n81 ",                                              $type_speed;    # to get crash dumps as text
+    type_string "console=tty ",                                                          $type_speed;
+    type_string "autoyast=http://147.2.207.67/install/autoinst/autoinst_ipmiserver.xml", $type_speed;
+    send_key 'ret';
+
+    $self->check_prompt_for_boot();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_login_proxy.pm
+++ b/tests/virt_autotest/proxymode_login_proxy.pm
@@ -7,23 +7,25 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
-# G-Maintainer: alice <xlai@suse.com>
 
 use strict;
 use warnings;
 use File::Basename;
+use base "opensusebasetest";
 use testapi;
-use base "reboot_and_wait_up";
 
 sub run() {
-    my $self    = shift;
-    my $timeout = 300;
-    $self->reboot_and_wait_up($timeout);
+    assert_screen "bootloader";
+    send_key "ret";
+    assert_screen "grub2", 10;
+    send_key "ret";
+    assert_screen "displaymanager", 300;
+    select_console('root-console');
+    sleep 2;
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {important => 1};
 }
 
 1;

--- a/tests/virt_autotest/proxymode_redirect_serial1.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial1.pm
@@ -1,0 +1,36 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+use base "proxymodeapi";
+
+sub run {
+    my $self = shift;
+
+    $self->create_nc();
+    $self->con_nc_from_tty();
+    $self->back_pre_tty();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/virt_autotest/proxymode_redirect_serial2.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial2.pm
@@ -1,0 +1,36 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+use base "proxymodeapi";
+
+sub run {
+    my $self = shift;
+
+    $self->create_nc();
+    $self->con_nc_from_tty();
+    $self->back_pre_tty();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/virt_autotest/proxymode_redirect_serial3.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial3.pm
@@ -1,0 +1,36 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+use base "proxymodeapi";
+
+sub run {
+    my $self = shift;
+
+    $self->create_nc();
+    $self->con_nc_from_tty();
+    $self->back_pre_tty();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/virt_autotest/proxymodeapi.pm
+++ b/tests/virt_autotest/proxymodeapi.pm
@@ -1,0 +1,152 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+package proxymodeapi;
+use strict;
+use base "opensusebasetest";
+use testapi;
+use base "virt_autotest_base";
+
+our $SLAVE_SERIALDEV = 'proxyserial';
+our $DEBUG           = 1;
+
+sub restart_host {
+    my $self         = shift;
+    my $ipmi_machine = get_var("IPMI_HOSTNAME");
+    my $ipmitool     = "ipmitool -H " . $ipmi_machine . " -U ADMIN -P ADMIN ";
+    $self->execute_script_run($ipmitool . 'chassis power off', 20);
+    while (1) {
+        my $stdout = $self->execute_script_run($ipmitool . 'chassis power status', 20);
+        last if $stdout =~ m/is off/;
+        script_run("", $ipmitool . 'chassis power off', 20);
+        sleep(2);
+    }
+
+    $self->execute_script_run($ipmitool . 'chassis power on', 20);
+    while (1) {
+        my $ret = $self->execute_script_run($ipmitool . 'chassis power status', 20);
+        last if $ret =~ m/is on/;
+        $self->execute_script_run("", $ipmitool . 'chassis power on', 20);
+        sleep(2);
+    }
+
+}
+
+sub connect_slave {
+    my $self = shift;
+    script_run("clear");
+    my $ipmi_machine = get_var("IPMI_HOSTNAME");
+    #type_string("ipmitool -H 147.2.208.125 -U ADMIN -P ADMIN -I lanplus sol activate\n");
+    type_string("ipmitool -H " . $ipmi_machine . " -U ADMIN -P ADMIN -I lanplus sol activate\n");
+    send_key 'ret';
+}
+
+sub check_prompt_for_boot() {
+    my $self    = shift;
+    my $timeout = shift;
+    if (!$timeout) {
+        $timeout = 5000;
+    }
+    assert_screen("autoyast-system-login-console", $timeout);
+    type_string "root\n";
+    sleep 2;
+    type_password;
+    send_key "ret";
+    assert_screen("text-logged-in-root", 10);
+    type_string("clear;ip a\n");
+}
+
+sub save_org_serialdev() {
+    my $self = shift;
+    if (!get_var("PROXY_SERIALDEV")) {
+        set_var("PROXY_SERIALDEV", $serialdev);
+    }
+}
+
+sub get_org_serialdev() {
+    my $self = shift;
+    return get_var("PROXY_SERIALDEV", "ttyS0");
+}
+
+sub resume_org_serialdev() {
+    my $self = shift;
+    $serialdev = $self->get_org_serialdev();
+}
+
+
+sub set_curr_serialdev() {
+    my $self = shift;
+    $serialdev = $SLAVE_SERIALDEV;
+}
+
+sub create_nc() {
+    my $self = shift;
+    # Create nc connection on root console
+    type_string "mkfifo /dev/$SLAVE_SERIALDEV\n";
+    sleep 2;
+    type_string "tail -f /dev/$SLAVE_SERIALDEV | nc -l 1234 &\n";
+    save_screenshot;
+
+    save_org_serialdev();
+}
+
+sub con_nc_from_tty() {
+    my $self    = shift;
+    my $console = shift;
+    my $test_machine;
+
+    if (!get_var("TEST_MACHINE")) {
+        die "Failed to get test machine ip";
+    }
+    else {
+        $test_machine = get_var("TEST_MACHINE");
+    }
+    if ($console) {
+        select_console $console;
+    }
+    else {
+        select_console 'log-console';
+    }
+    wait_still_screen(2);
+    send_key "ctrl-c";
+    send_key "ctrl-c";
+
+    my $proxy_serialdev = get_var("PROXY_SERIALDEV", "ttyS0");
+
+    if ($DEBUG) {
+        type_string "#nc ${test_machine} 1234 |tee /dev/" . $proxy_serialdev . "\n";
+    }
+
+    type_string "nc ${test_machine} 1234 |tee /dev/" . $proxy_serialdev . "\n";
+    sleep 3;
+    save_screenshot;
+}
+
+sub back_pre_tty() {
+    my $self = shift;
+    # Back to previous console and prepare for next steps
+    select_console "root-console";
+
+    set_curr_serialdev();
+
+    my $pattern = 'NC_CONNECTION_TEST-' . int(rand(999999));
+    type_string "echo $pattern |tee /dev/$serialdev\n";
+    if (!wait_serial($pattern, 10)) {
+        die "Failed to build the connection between slave machine and proxy machine\n";
+    }
+    save_screenshot;
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up_normal2.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal2.pm
@@ -23,7 +23,7 @@ sub run() {
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/reboot_and_wait_up_normal3.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal3.pm
@@ -23,7 +23,7 @@ sub run() {
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use base "opensusebasetest";
+use File::Basename;
+use testapi;
+
+use base "virt_autotest_base";
+use virt_utils;
+
+sub update_package() {
+    my $self           = shift;
+    my $test_type      = get_var('TEST_TYPE', 'Milestone');
+    my $update_pkg_cmd = "source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms";
+    my $ret;
+    if ($test_type eq 'Milestone') {
+        $update_pkg_cmd = $update_pkg_cmd . " off on off";
+    }
+    else {
+        $update_pkg_cmd = $update_pkg_cmd . " off off on";
+    }
+
+    $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
+    $ret = $self->execute_script_run($update_pkg_cmd, 7200);
+    upload_logs("/tmp/update_virt_rpms.log");
+    save_screenshot;
+    if ($ret !~ /Need to reboot system to make the rpms work/m) {
+        die " Update virt rpms fail, going to terminate following test!";
+    }
+
+}
+
+sub run() {
+    my $self = shift;
+    $self->update_package();
+    if (!get_var("PROXY_VIRT_AUTOTEST")) {
+        setup_console_in_grub;
+        repl_repo_in_sourcefile();
+    }
+}
+
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+


### PR DESCRIPTION
Add the proxy mode as extension of ipmi mode for using physical machine to do test.

*Terms:
Proxy machine : The machine is qemu vm which is created by openqa
Slave machine : The physical machine.

*Policy:
Using proxy machine as a agency to control physical machine to finish test

*Problems:
-Comparing with ipmi mode , we need to solve following problems.
1. Using proxy to connect/control slave machine
2. Redirect serial port from slave machine to proxy machine.

*Solution:
Problem 1: Using ipmitoll as interactive medium to connect slave machine.
Problem 2: Using *nc* to redirect special file descriptor of slave machine to standard serial port of proxy machine, make all output in slave machine be redirected to serial port of proxy machine. 

*Usage:
1. use proxymode_login_proxy.pm to login to proxy machine
2. use proxymode_conn_slave.pm to connect to slave machine (take ipmitool as communication medium)
3. use proxymode_redirect_serial1.pm to redirect  #serial port from slave to proxy machine. (Create nc between slave and proxy)
4. user self-defined test.

*Sample:
I finished guest installation test of virtualization using this method, http://147.2.212.248/tests/265#live

*Hope:
Anyone who has any idea , advice and suggestions, Please add the comment or send mail to us qa-apac2@suse.com  ,   Thanks in advance.